### PR TITLE
Fix appname error

### DIFF
--- a/bakery_app/management/apps.py
+++ b/bakery_app/management/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class AManagementConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
-    name = "management"
+    name = "bakery_app.management"


### PR DESCRIPTION
El error se daba porque el appname en `management.apps` estaba mal declarado. Lo más probable es que este error se dió porque inicisiaste la app en el `root ` del proyecto y luego moviste el directorio a `bakery_app` y sin cambiar el app name en `apps.py`. IDEs como Pycharm hacen esto automáticamente pero en VsCode se debe hacer manualmente. 